### PR TITLE
[fix] 상품 판매 데이터 집계 시 사용되는 recordProductSale 관련 메서드를 infra -> core로 이동

### DIFF
--- a/src/main/kotlin/kr/hhplus/be/server/core/product/domain/ProductSale.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/core/product/domain/ProductSale.kt
@@ -23,9 +23,48 @@ class ProductSale(
     @Column(name = "created_at", nullable = false)
     val createdAt: Long = System.currentTimeMillis()
 
+    companion object {
+
+        /**
+         * 새로운 판매 데이터 생성 팩토리 메서드
+         * @param productId 상품 ID
+         * @param saleDate 판매 날짜 (YYYYMMDD 형태)
+         * @param quantity 판매 수량
+         * @return 새로운 ProductSale 인스턴스
+         */
+        fun createNewSale(
+            productId: Long,
+            saleDate: Long,
+            quantity: Int,
+        ): ProductSale {
+            return ProductSale(
+                productId = productId,
+                saleDate = saleDate,
+                totalQuantity = quantity,
+            )
+        }
+    }
+
     init {
         require(productId > 0) { "상품 ID는 0보다 커야 합니다. 입력된 ID: $productId" }
         require(saleDate > 0) { "판매 날짜는 0보다 커야 합니다. 입력된 날짜: $saleDate" }
         require(totalQuantity >= 0) { "총 판매량은 0 이상이어야 합니다. 입력된 판매량: $totalQuantity" }
+    }
+
+    /**
+     * 판매 수량 추가
+     * 기존 판매량에 새로운 판매량을 추가하여 새로운 ProductSale 인스턴스를 반환
+     *
+     * @param additionalQuantity 추가할 판매 수량
+     * @return 수량이 추가된 새로운 ProductSale 인스턴스
+     */
+    fun addSaleQuantity(additionalQuantity: Int): ProductSale {
+        val newTotalQuantity = this.totalQuantity + additionalQuantity
+
+        return ProductSale(
+            productId = this.productId,
+            saleDate = this.saleDate,
+            totalQuantity = newTotalQuantity,
+        )
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/core/product/repository/ProductSaleRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/core/product/repository/ProductSaleRepository.kt
@@ -23,14 +23,20 @@ interface ProductSaleRepository {
     ): List<ProductPeriodSaleDto>
 
     /**
-     * 상품 판매량 데이터 저장/업데이트
+     * 상품 판매량 데이터 저장
+     * @param productSale 저장할 ProductSale 도메인 객체
+     * @return 저장된 ProductSale 도메인 객체
+     */
+    fun save(productSale: ProductSale): ProductSale
+
+    /**
+     * 특정 상품의 특정 날짜 판매 데이터 조회
      * @param productId 상품 ID
      * @param saleDate 판매 날짜 (YYYYMMDD 형태)
-     * @param quantity 판매 수량
+     * @return 해당 조건의 ProductSale 또는 null
      */
-    fun saveProductSale(
+    fun findByProductIdAndSaleDate(
         productId: Long,
         saleDate: Long,
-        quantity: Int,
-    )
+    ): ProductSale?
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infra/persistence/product/ProductSaleRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infra/persistence/product/ProductSaleRepositoryImpl.kt
@@ -36,31 +36,21 @@ class ProductSaleRepositoryImpl(
         )
     }
 
-    override fun saveProductSale(
+    /**
+     * ProductSale 도메인 객체 저장
+     * Infrastructure 계층은 순수하게 데이터 접근만 담당
+     */
+    override fun save(productSale: ProductSale): ProductSale {
+        return jpaProductSaleRepository.save(productSale)
+    }
+
+    /**
+     * 상품 ID와 판매 날짜로 ProductSale 조회
+     */
+    override fun findByProductIdAndSaleDate(
         productId: Long,
         saleDate: Long,
-        quantity: Int,
-    ) {
-        val existingProductSale = jpaProductSaleRepository.findByProductIdAndSaleDate(productId, saleDate)
-
-        if (existingProductSale != null) {
-            // 기존 데이터가 있으면 수량 업데이트 (새 엔티티 생성)
-            val updatedProductSale =
-                ProductSale(
-                    productId = productId,
-                    saleDate = saleDate,
-                    totalQuantity = existingProductSale.totalQuantity + quantity,
-                )
-            jpaProductSaleRepository.save(updatedProductSale)
-        } else {
-            // 새 데이터 생성
-            val newProductSale =
-                ProductSale(
-                    productId = productId,
-                    saleDate = saleDate,
-                    totalQuantity = quantity,
-                )
-            jpaProductSaleRepository.save(newProductSale)
-        }
+    ): ProductSale? {
+        return jpaProductSaleRepository.findByProductIdAndSaleDate(productId, saleDate)
     }
 }


### PR DESCRIPTION
 (Core=Service+Doamin)

<!--
  제목은 [STEP] (작업한 내용) 로 작성해 주세요
  예시: [STEP-5] 이커머스 시스템 설계 
-->
## ✅ 관련 이슈 번호 및 커밋 정보
<!--
  이슈를 먼저 만든 후 #숫자를 통해 이슈를 적고, 오른쪽에는 관련 커밋들을 기록합니다.
  예시 : #13 : 06f7c46d68b384702e6f941863eb6853708df2cd
-->
- #24  
  - 상품 판매 관련 로직 변경 : 9adf398914953c26d6c23cc74724a1c3c92d75a9  

## 🔥 PR 설명
<!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->
  -  상품 판매 관련 로직 중 비즈니스로직이 infra에 있었음 -> service 쪽으로 이동시킴

## ⭐️ 리뷰 포인트
<!-- 
    해당 PR 요청 시, 노력했던 부분을 나열해주세요.
    팀원이 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
-->

## ⏰ 프로젝트 정보
- [타임라인 뷰](https://github.com/users/lostcatbox/projects/3/views/3)
