### PR TITLE
[추가 문서 및 개선] 분산락 트랜잭션 순서 문제 해결

### DIFF
--- a/common/src/main/kotlin/kr/hhplus/be/server/support/lock/DistributedLockManager.kt
+++ b/common/src/main/kotlin/kr/hhplus/be/server/support/lock/DistributedLockManager.kt
@@ -20,11 +20,6 @@ class DistributedLockManager(
 ) : DistributedLockManagerInterface {
     private val logger = LoggerFactory.getLogger(DistributedLockManager::class.java)
 
-    companion object {
-        private const val DEFAULT_WAIT_TIME = 5L
-        private const val DEFAULT_LEASE_TIME = 10L
-    }
-
     /**
      * 분산락을 획득하고 트랜잭션 내에서 비즈니스 로직을 실행
      *

--- a/core/src/main/kotlin/kr/hhplus/be/server/config/RedisConfig.kt
+++ b/core/src/main/kotlin/kr/hhplus/be/server/config/RedisConfig.kt
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+    @Bean
+    fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
+        val template = RedisTemplate<String, String>()
+        template.connectionFactory = connectionFactory
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = StringRedisSerializer()
+        template.hashKeySerializer = StringRedisSerializer()
+        template.hashValueSerializer = StringRedisSerializer()
+        return template
+    }
+
+    @Bean
+    fun objectRedisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
+        val template = RedisTemplate<String, Any>()
+        template.connectionFactory = connectionFactory
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = GenericJackson2JsonRedisSerializer()
+        template.hashKeySerializer = StringRedisSerializer()
+        template.hashValueSerializer = GenericJackson2JsonRedisSerializer()
+        return template
+    }
+}

--- a/core/src/main/kotlin/kr/hhplus/be/server/config/RedissonConfig.kt
+++ b/core/src/main/kotlin/kr/hhplus/be/server/config/RedissonConfig.kt
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonConfig(
+    @Value("\${spring.data.redis.host}")
+    private val redissonHost: String,
+    @Value("\${spring.data.redis.port}")
+    private val redissonPort: Int,
+) {
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val redissonConfig = Config()
+        redissonConfig.useSingleServer().setAddress("$REDISSON_HOST_PREFIX$redissonHost:$redissonPort")
+        return Redisson.create(redissonConfig)
+    }
+
+    companion object {
+        private const val REDISSON_HOST_PREFIX = "redis://"
+    }
+}

--- a/coupon/src/main/kotlin/kr/hhplus/be/server/core/coupon/service/UserCouponService.kt
+++ b/coupon/src/main/kotlin/kr/hhplus/be/server/core/coupon/service/UserCouponService.kt
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.core.coupon.service
 import kr.hhplus.be.server.core.coupon.domain.UserCoupon
 import kr.hhplus.be.server.core.coupon.repository.UserCouponRepository
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 /**
@@ -31,7 +32,7 @@ class UserCouponService(
     /**
      * 사용자 쿠폰 발급
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED)
     fun createUserCoupon(
         userId: Long,
         couponId: Long,

--- a/coupon/src/test/kotlin/kr/hhplus/be/server/core/coupon/service/CouponServiceIntegrationTest.kt
+++ b/coupon/src/test/kotlin/kr/hhplus/be/server/core/coupon/service/CouponServiceIntegrationTest.kt
@@ -12,15 +12,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import kr.hhplus.be.server.infrastructure.kafka.producer.CouponIssueEventProducer
-import kr.hhplus.be.server.infrastructure.kafka.service.KafkaCouponIssueQueueService
 
 @DisplayName("CouponService 통합 테스트")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)

--- a/docs/report/report-of-distributed-lock-transaction-issue.md
+++ b/docs/report/report-of-distributed-lock-transaction-issue.md
@@ -1,0 +1,138 @@
+# 분산락 트랜잭션 순서 문제 해결 보고서
+## 목차
+- 문제점
+- 해결방법
+- 결론
+
+## 문제점
+
+### 기존 코드의 트랜잭션 순서 문제
+
+**기존 코드:**
+
+```kotlin
+// ❌ 기존 코드
+@Transactional  // TX1 시작
+override fun issueCoupon(request: CouponIssueRequest): UserCoupon {
+    validateCouponId(request.couponId)
+
+    val lockKey = "lock:coupon-issue:${request.couponId}"
+    distributedLockManager.executeWithLock(lockKey) {  // TX2 시작
+        // 쿠폰 재고 차감
+        coupon.issueCoupon()
+        couponRepository.save(coupon)
+        // TX2 커밋 ✓
+    } // 락 해제 ✓
+
+    //  ❌ 문제: TX1은 아직 커밋 안됨, 락은 이미 해제됨!
+    val userCoupon = userCouponService.createUserCoupon(request.userId, request.couponId)
+    return userCoupon
+    // TX1 커밋
+}
+```
+
+### 잘못된 실행 순서
+
+```
+TX1 시작 → 락 획득 → TX2 시작 → 비즈니스 로직 → TX2 커밋 → 락 해제 → TX1 커밋
+                                                            ↑
+                                              문제 발생 지점: 락은 해제되었지만 TX1은 아직 진행 중
+```
+
+### 발생 가능한 문제
+
+1. **데이터 정합성 위험**: 분산락이 해제된 후에도 외부 트랜잭션(TX1)이 진행 중
+2. **Dirty Read 가능성**: 다른 스레드가 락을 획득하면 아직 커밋되지 않은 데이터를 조회할 수 있음
+3. **동시성 제어 실패**: 분산락의 목적이 무용지물
+
+---
+
+## 해결방법
+
+### 핵심 원칙
+
+분산락 사용 시 반드시 지켜야 하는 순서:
+
+```
+락 획득 → 트랜잭션 시작 → 비즈니스 로직 → 트랜잭션 커밋 → 락 해제
+```
+
+### 해결 전략
+
+`DistributedLockManager.executeWithLock()`는 내부적으로 `TransactionTemplate`을 사용하여 트랜잭션을 관리합니다.
+따라서 이 트랜잭션만 사용하도록 코드를 수정했습니다.
+
+**수정 내용:**
+
+1. `CouponService.issueCoupon()`의 `@Transactional` 어노테이션 **제거**
+2. `userCouponService.createUserCoupon()` 호출을 `executeWithLock { }` **내부로 이동**
+3. `UserCouponService.createUserCoupon()`의 `@Transactional(REQUIRED)`가 기존 트랜잭션에 참여하도록 구성
+
+---
+
+## 결과
+
+### 최종 코드
+
+```kotlin
+// ✅ 수정된 코드
+// @Transactional 제거
+override fun issueCoupon(request: CouponIssueRequest): UserCoupon {
+    try {
+        validateCouponId(request.couponId)
+
+        val lockKey = "lock:coupon-issue:${request.couponId}"
+
+        // 분산락 내에서 모든 로직 처리
+        return distributedLockManager.executeWithLock(lockKey) {  // TX 시작
+            // 1. 쿠폰 재고 차감
+            val coupon = couponRepository.findByCouponIdWithPessimisticLock(request.couponId)
+                ?: throw IllegalArgumentException("존재하지 않는 쿠폰입니다. 쿠폰 ID: ${request.couponId}")
+
+            coupon.issueCoupon()
+            couponRepository.save(coupon)
+
+            // 2. 사용자 쿠폰 생성 (같은 트랜잭션 내에서)
+            userCouponService.createUserCoupon(request.userId, request.couponId)
+            // TX 커밋 ✓
+        } // 락 해제 ✓
+    } catch (e: Exception) {
+        throw e
+    }
+}
+```
+
+### 올바른 실행 순서
+
+```
+락 획득 → 트랜잭션 시작 → 쿠폰 재고 차감 → UserCoupon 생성 → 트랜잭션 커밋 → 락 해제
+```
+
+### 개선 효과
+
+- ✅ **올바른 순서 보장**: 락 → 트랜잭션 → 비즈니스로직 → 커밋 → 락 해제
+- ✅ **단일 트랜잭션**: 모든 DB 작업이 하나의 트랜잭션에서 실행되어 원자성 보장
+- ✅ **데이터 정합성**: 완벽한 데이터 정합성 보장
+
+---
+
+## 📊 Before / After 비교
+
+| 구분 | 기존 코드 | 개선 코드 |
+|------|----------|----------|
+| **외부 @Transactional** | ❌ 있음 (문제) | ✅ 제거 |
+| **트랜잭션 개수** | 2개 (TX1, TX2) | 1개 (TX) |
+| **락 해제 시점** | TX1 커밋 전 | TX 커밋 후 |
+| **실행 순서** | 락 → TX2 → 락해제 → TX1 | 락 → TX → 락해제 |
+| **데이터 정합성** | ⚠️ 위험 | ✅ 안전 |
+| **UserCoupon 생성 위치** | 락 외부 | 락 내부 |
+
+---
+
+## 🎯 결론
+
+분산락을 사용할 때는 **락 내부에서만 트랜잭션이 생성되고 커밋되도록** 보장해야 합니다.
+외부에 `@Transactional`이 있으면 트랜잭션이 락 범위를 벗어나 데이터 정합성 문제가 발생할 수 있습니다.
+
+**핵심 원칙**: 락 획득 → 트랜잭션 → 비즈니스 로직 → 트랜잭션 커밋 → 락 해제
+


### PR DESCRIPTION
<!--
  제목은 [STEP] (작업한 내용) 로 작성해 주세요
  예시: [STEP-5] 이커머스 시스템 설계 
-->
## ✅ 관련 이슈 번호 및 커밋 정보
<!--
  이슈를 먼저 만든 후 #숫자를 통해 이슈를 적고, 오른쪽에는 관련 커밋들을 기록합니다.
  예시 : #13 : 06f7c46d68b384702e6f941863eb6853708df2cd
-->
- close #68 : cf3f944193f19e46720a74909a73a552498420bc
- close #69 : f03be9156669d300bdaeba7b90923a2ddb01d26f
- close #70 : 750233ce6c87b0a0e997070bec7ddf5b6810b66f
## 🔥 PR 설명
<!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->

### 기존 코드의 트랜잭션 순서 문제

**기존 코드:** 잘못된 실행 순서를 가진 구조 발견. 
모든 트랜잭션을 분산락 안에서만 생성 및 커밋되도록 구조 변경

```kotlin
// ❌ 기존 코드
@Transactional  // TX1 시작
override fun issueCoupon(request: CouponIssueRequest): UserCoupon {
    validateCouponId(request.couponId)

    val lockKey = "lock:coupon-issue:${request.couponId}"
    distributedLockManager.executeWithLock(lockKey) {  // TX2 시작
        // 쿠폰 재고 차감
        coupon.issueCoupon()
        couponRepository.save(coupon)
        // TX2 커밋 ✓
    } // 락 해제 ✓

    //  ❌ 문제: TX1은 아직 커밋 안됨, 락은 이미 해제됨!
    val userCoupon = userCouponService.createUserCoupon(request.userId, request.couponId)
    return userCoupon
    // TX1 커밋
}
```

### 잘못된 실행 순서

```
TX1 시작 → 락 획득 → TX2 시작 → 비즈니스 로직 → TX2 커밋 → 락 해제 → TX1 커밋
                                                            ↑
                                              문제 발생 지점: 락은 해제되었지만 TX1은 아직 진행 중
```



## ⭐️ 리뷰 포인트
<!-- 
    해당 PR 요청 시, 노력했던 부분을 나열해주세요.
    팀원이 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
-->

## ⏰ 프로젝트 정보
- [타임라인 뷰](https://github.com/users/lostcatbox/projects/3/views/3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces transactional execution within the distributed lock for coupon issuing, adds Redis/Redisson configuration, updates tests, and documents the locking/transaction ordering fix.
> 
> - **Locking & Transactions**
>   - Centralizes coupon issuing into a single transaction executed inside `DistributedLockManager.executeWithLock` in `CouponService.issueCoupon`, removing external `@Transactional` and moving `userCouponService.createUserCoupon` inside the lock.
>   - `UserCouponService.createUserCoupon` now `@Transactional(propagation = REQUIRED)` to join the enclosing transaction.
>   - `DistributedLockManager` executes business logic via `TransactionTemplate` within the lock; unused default timing constants removed.
> - **Configuration**
>   - Add `RedisConfig` providing `RedisTemplate<String, String>` and `RedisTemplate<String, Any>` with appropriate serializers.
>   - Add `RedissonConfig` to create `RedissonClient` from `spring.data.redis.host`/`port`.
> - **Tests**
>   - Update `CouponServiceIntegrationTest` to verify stock decrement, error cases, concurrency behavior, and transactional rollback; remove unused mocks.
> - **Docs**
>   - Add `docs/report/report-of-distributed-lock-transaction-issue.md` explaining the transaction-ordering issue and the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 750233ce6c87b0a0e997070bec7ddf5b6810b66f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->